### PR TITLE
Add port to url in config.js.example

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -3,7 +3,7 @@ module.exports = {
     interval: 60000,
 
     // Port and Host for the web interface.
-    port: 3000,
+    port: 3000, // Unless you have forwarding configured, include this port in the url on line 18, below.
     host: '127.0.0.1',
     ssl: null,
     // If you want to use SSL (you should), use this config for ssl:
@@ -15,7 +15,7 @@ module.exports = {
     //    ca: 'path_to_ca.pem'
     //},
 
-    url: 'http://localhost', // The url for your service. Needed for the links in confirmation emails.
+    url: 'http://localhost:3000', // The url for your service. Needed for the links in confirmation emails.
 
     // Location of the storage file. Contains all API-Keys.
     storageFile: './storage.js',


### PR DESCRIPTION
I was getting redirected to http://localhost, causing my browser to request port 80. However, the default port in the example is 3000
